### PR TITLE
correcting html typo

### DIFF
--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -261,7 +261,7 @@
     "reports.a8.description.long": "<strong>Wie viele Zertifikate der verschiedenen Zertifikatstypen wurden schweizweit pro Woche (max. letzte 3 Monate) über welche Kanäle ausgestellt?</strong></br></br>Dieser Report liefert Ihnen eine wochenweise Liste von Zertifikatstypen und deren jeweilige Anzahl pro Ausstellkanal (je Woche ein Tabellenblatt). Die Zahlen beziehen sich auf die gesamte Schweiz, eine Einschränkung des Datenraums auf einzelne Kantone ist nicht möglich. Das zweite bis x-te Tabellenblatt weisst dabei zusätzlich die Differenz zur Vorwoche aus.",
     "reports.a8.description.short": "Wochenweise Anzahl Zertifikate pro Typ, gegliedert nach Ausstellkanal.",
     "reports.a8.title": "A8",
-    "reports.a9.description.long": "<strongWie viele Zertifikate der verschiedenen Zertifikatstypen wurden bisher über den gesamten Ausstellungszeitraum über welche Kanäle ausgestellt?></strong></br></br>Dieser Report liefert Ihnen die Gesamtanzahl der ausgestellten Zertifikate eines Typs und die Kanäle, über welche sie ausgestellt wurden.",
+    "reports.a9.description.long": "<strong>Wie viele Zertifikate der verschiedenen Zertifikatstypen wurden bisher über den gesamten Ausstellungszeitraum über welche Kanäle ausgestellt?</strong></br></br>Dieser Report liefert Ihnen die Gesamtanzahl der ausgestellten Zertifikate eines Typs und die Kanäle, über welche sie ausgestellt wurden.",
     "reports.a9.description.short": "Gesamtanzahl Zertifikate eines Typs im gesamten Ausstellungszeitraum, gegliedert nach Ausstellkanal.",
     "reports.a9.title": "A9",
     "reports.aggregation.header": "Sie möchten prüfen, ob die Zahlen zur Zertifikatsausstellung in Ihrem Kanton auf einen allfälligen Missbrauchsfall hinweisen? Erstellen Sie dazu einen Aggregationsreport.",


### PR DESCRIPTION
in the german translation file was a html tag poorly formatted. The popup which contains the string did therefore not display the whole text