### PR TITLE
Feature/vaccinecer 2201 validierung geb. datum und test/impfdatum nicht mehr vorhanden

### DIFF
--- a/src/app/create/components/personal-data/personal-data.component.spec.ts
+++ b/src/app/create/components/personal-data/personal-data.component.spec.ts
@@ -1,6 +1,6 @@
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {ReactiveFormsModule} from '@angular/forms';
+import {FormBuilder, FormGroupDirective, ReactiveFormsModule} from '@angular/forms';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
@@ -21,6 +21,12 @@ describe('PersonalDataComponent', () => {
 	const dateToOld: Date = new Date('1899-12-31');
 
 	beforeEach(async () => {
+		const fb = new FormBuilder();
+		const formGroupDirective = new FormGroupDirective([], []);
+		formGroupDirective.form = fb.group({
+			test: fb.control(null)
+		});
+
 		await TestBed.configureTestingModule({
 			declarations: [PersonalDataComponent, DateTimePickerComponent],
 			imports: [
@@ -32,6 +38,10 @@ describe('PersonalDataComponent', () => {
 				MatFormFieldModule,
 				MatInputModule,
 				MatAutocompleteModule
+			],
+			providers: [
+				FormGroupDirective,
+				{provide: FormGroupDirective, useValue: formGroupDirective}
 			],
 			schemas: [NO_ERRORS_SCHEMA]
 		}).compileComponents();

--- a/src/app/create/components/personal-data/personal-data.component.ts
+++ b/src/app/create/components/personal-data/personal-data.component.ts
@@ -1,21 +1,26 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {FormBuilder, FormGroup, FormGroupDirective, Validators} from '@angular/forms';
+import {ControlContainer, FormBuilder, FormGroup, FormGroupDirective, NgForm, Validators} from '@angular/forms';
 import {TranslateService} from '@ngx-translate/core';
-import {ProductInfo} from 'shared/model';
+import {PersonalData, ProductInfo} from 'shared/model';
 import {CreationDataService} from '../../utils/creation-data.service';
 import {DateValidators} from '../../utils/date-validators';
 import {ValueSetsService} from '../../utils/value-sets.service';
+import {DateMapper} from "../../utils/date-mapper";
 
 @Component({
 	selector: 'ec-personal-data',
 	templateUrl: './personal-data.component.html',
-	styleUrls: ['./personal-data.component.scss']
+	styleUrls: ['./personal-data.component.scss'],
+	viewProviders: [{ provide: ControlContainer, useExisting: NgForm }]
 })
 export class PersonalDataComponent implements OnInit {
+	public static readonly FORM_GROUP_NAME = 'personalData';
+
 	@ViewChild('formDirective') formDirective: FormGroupDirective;
 	public vaccineForm: FormGroup;
 
 	constructor(
+		private parent: FormGroupDirective,
 		private readonly formBuilder: FormBuilder,
 		private readonly valueSetsService: ValueSetsService,
 		private readonly translateService: TranslateService,
@@ -47,6 +52,15 @@ export class PersonalDataComponent implements OnInit {
 		element.blur();
 	}
 
+	public mapFormToPersonalData(): PersonalData {
+		return {
+			firstName: this.vaccineForm.value.firstName,
+			surName: this.vaccineForm.value.personal.value.surName,
+			birthdate: DateMapper.getBirthdate(this.vaccineForm.value.personal.value.birthdate),
+			language: this.vaccineForm.value.personal.value.certificateLanguage.code,
+		};
+	}
+
 	private getDefaultCertificateLanguage(): ProductInfo {
 		return this.translateService.currentLang === 'en'
 			? this.getCertificateLanguages().find(lang => lang.code === 'de')
@@ -69,6 +83,8 @@ export class PersonalDataComponent implements OnInit {
 			certificateLanguage: [this.getDefaultCertificateLanguage(), Validators.required],
 			checkBox: [{value: false, disabled: true}, Validators.requiredTrue]
 		});
+
+		this.parent.form.addControl(PersonalDataComponent.FORM_GROUP_NAME, this.vaccineForm);
 	}
 
 	private resetForm(): void {

--- a/src/app/create/components/personal-data/personal-data.component.ts
+++ b/src/app/create/components/personal-data/personal-data.component.ts
@@ -55,9 +55,9 @@ export class PersonalDataComponent implements OnInit {
 	public mapFormToPersonalData(): PersonalData {
 		return {
 			firstName: this.vaccineForm.value.firstName,
-			surName: this.vaccineForm.value.personal.value.surName,
-			birthdate: DateMapper.getBirthdate(this.vaccineForm.value.personal.value.birthdate),
-			language: this.vaccineForm.value.personal.value.certificateLanguage.code,
+			surName: this.vaccineForm.value.surName,
+			birthdate: DateMapper.getBirthdate(this.vaccineForm.value.birthdate),
+			language: this.vaccineForm.value.certificateLanguage.code,
 		};
 	}
 

--- a/src/app/create/exceptional-form/exceptional-form.component.spec.ts
+++ b/src/app/create/exceptional-form/exceptional-form.component.spec.ts
@@ -11,10 +11,20 @@ import {MatInputModule} from '@angular/material/input';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {PersonalDataComponent} from "../components/personal-data/personal-data.component";
+import {CreationDataService} from "../utils/creation-data.service";
+import * as moment from "moment";
+import {ValueSetsService} from "../utils/value-sets.service";
 
 describe('ExceptionalFormComponent', () => {
 	let component: ExceptionalFormComponent;
 	let fixture: ComponentFixture<ExceptionalFormComponent>;
+	let creationDataService: CreationDataService;
+
+	const mockValueSetsService = {
+		getCertificateLanguages: jest.fn().mockReturnValue([]),
+		getVaccines: jest.fn().mockReturnValue([]),
+		getCountryOptions: jest.fn().mockReturnValue([{code: 'CH', display: 'TEST-CH'}, {code: 'DE', display: 'TEST-DE'}])
+	};
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
@@ -29,17 +39,78 @@ describe('ExceptionalFormComponent', () => {
 				MatInputModule,
 				MatAutocompleteModule
 			],
+			providers: [
+				{
+					provide: ValueSetsService,
+					useValue: mockValueSetsService
+				}
+			],
 			schemas: [NO_ERRORS_SCHEMA]
 		}).compileComponents();
 	});
 
 	beforeEach(() => {
 		fixture = TestBed.createComponent(ExceptionalFormComponent);
+		creationDataService = TestBed.inject(CreationDataService);
 		component = fixture.componentInstance;
 		fixture.detectChanges();
 	});
 
 	it('should create', () => {
 		expect(component).toBeTruthy();
+	});
+
+	describe('Form reset', () => {
+		it('should reset the firstName correctly', () => {
+			component.exceptionalForm.get('firstName').setValue('TEST');
+			creationDataService.emitResetCalled();
+			expect(component.exceptionalForm.value.firstName).toBeNull();
+		});
+
+		it('should reset the surName correctly', () => {
+			component.exceptionalForm.get('surName').setValue('TEST');
+			creationDataService.emitResetCalled();
+			expect(component.exceptionalForm.value.surName).toBeNull();
+		});
+
+		it('should reset the birthdate correctly', () => {
+			component.exceptionalForm.get('birthdate').setValue('TEST');
+			creationDataService.emitResetCalled();
+			expect(component.exceptionalForm.value.birthdate).toEqual({date: null, time: null});
+		});
+
+		it('should reset the certificateLanguage correctly', () => {
+			component.exceptionalForm.get('certificateLanguage').setValue({display: 'TEST', code: 'lang'});
+			creationDataService.emitResetCalled();
+			expect(component.exceptionalForm.value.certificateLanguage).toEqual({display: 'TEST', code: 'lang'});
+		});
+
+		it('should reset the countryOfTest correctly', () => {
+			component.exceptionalForm.get('countryOfTest').setValue({display: 'TEST-DE', code: 'DE'});
+			creationDataService.emitResetCalled();
+			expect(component.exceptionalForm.value.countryOfTest).toEqual({display: 'TEST-CH', code: 'CH'});
+		});
+
+		it('should reset the center correctly', () => {
+			component.exceptionalForm.get('center').setValue('Testcenter');
+			creationDataService.emitResetCalled();
+			expect(component.exceptionalForm.value.center).toEqual('Testcenter');
+		});
+
+		it('should reset the sampleDate correctly', () => {
+			const dateString = '2021-08-24T08:00:00.482Z';
+			const date = new Date(dateString);
+			Date.now = jest.fn().mockReturnValue(date);
+			component.exceptionalForm.get('sampleDate').setValue('TEST');
+			creationDataService.emitResetCalled();
+			const momentDate: moment.Moment = component.exceptionalForm.value.sampleDate.date;
+			expect(momentDate.toISOString()).toEqual(dateString);
+		});
+
+		it('should reset the checkBox correctly', () => {
+			component.exceptionalForm.get('checkBox').setValue(true);
+			creationDataService.emitResetCalled();
+			expect(component.exceptionalForm.value.checkBox).toBeFalsy();
+		});
 	});
 });

--- a/src/app/create/exceptional-form/exceptional-form.component.spec.ts
+++ b/src/app/create/exceptional-form/exceptional-form.component.spec.ts
@@ -10,6 +10,7 @@ import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
 import {MatAutocompleteModule} from '@angular/material/autocomplete';
 import {NO_ERRORS_SCHEMA} from '@angular/core';
+import {PersonalDataComponent} from "../components/personal-data/personal-data.component";
 
 describe('ExceptionalFormComponent', () => {
 	let component: ExceptionalFormComponent;
@@ -17,7 +18,7 @@ describe('ExceptionalFormComponent', () => {
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
-			declarations: [ExceptionalFormComponent, DateTimePickerComponent],
+			declarations: [ExceptionalFormComponent, DateTimePickerComponent, PersonalDataComponent],
 			imports: [
 				NoopAnimationsModule,
 				ObliqueTestingModule,

--- a/src/app/create/recovery-form/recovery-form.component.spec.ts
+++ b/src/app/create/recovery-form/recovery-form.component.spec.ts
@@ -21,6 +21,7 @@ describe('RecoveryFormComponent', () => {
 	const dateFuture: Date = new Date('9999-04-29');
 	const datePast: Date = new Date('2000-04-29');
 	const dateToOld: Date = new Date('1899-12-31');
+	const timeNoon = '12:00';
 
 	const mockValueSetsService = {
 		getCertificateLanguages: jest.fn().mockReturnValue([]),
@@ -91,6 +92,19 @@ describe('RecoveryFormComponent', () => {
 
 			it('should marks the dateFirstPositiveTestResult as valid if set correctly', () => {
 				component.recoveryForm.get('dateFirstPositiveTestResult').setValue({date: datePast});
+				expect(component.recoveryForm.get('dateFirstPositiveTestResult').invalid).toBeFalsy();
+			});
+
+			it('should mark the dateFirstPositiveTestResult as invalid if set before birthdate', () => {
+				const dateAhead = moment(datePast).clone().add({days: 1})
+				component.recoveryForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.birthdate').setValue({date: dateAhead.toDate(), time: timeNoon});
+				component.recoveryForm.get('dateFirstPositiveTestResult').setValue({date: datePast, time: timeNoon});
+				expect(component.recoveryForm.get('dateFirstPositiveTestResult').invalid).toBeTruthy();
+			});
+
+			it('should mark the dateFirstPositiveTestResult as valid if set after/equal birthdate', () => {
+				component.recoveryForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.birthdate').setValue(datePast);
+				component.recoveryForm.get('dateFirstPositiveTestResult').setValue({date: datePast, time: timeNoon});
 				expect(component.recoveryForm.get('dateFirstPositiveTestResult').invalid).toBeFalsy();
 			});
 		});

--- a/src/app/create/recovery-form/recovery-form.component.spec.ts
+++ b/src/app/create/recovery-form/recovery-form.component.spec.ts
@@ -24,7 +24,7 @@ describe('RecoveryFormComponent', () => {
 
 	const mockValueSetsService = {
 		getCertificateLanguages: jest.fn().mockReturnValue([]),
-		getCountryOptions: jest.fn().mockReturnValue([])
+		getCountryOptions: jest.fn().mockReturnValue([{code: 'CH', display: 'TEST-CH'}, {code: 'DE', display: 'TEST-DE'}])
 	};
 
 	beforeEach(async () => {
@@ -173,6 +173,44 @@ describe('RecoveryFormComponent', () => {
 			component.goNext();
 
 			expect(setNewPatientSpy).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('Form reset', () => {
+		it('should reset the firstName correctly', () => {
+			component.recoveryForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.firstName').setValue('TEST');
+			creationDataService.emitResetCalled();
+			expect(component.recoveryForm.value[PersonalDataComponent.FORM_GROUP_NAME].firstName).toBeNull();
+		});
+
+		it('should reset the surName correctly', () => {
+			component.recoveryForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.surName').setValue('TEST');
+			creationDataService.emitResetCalled();
+			expect(component.recoveryForm.value[PersonalDataComponent.FORM_GROUP_NAME].surName).toBeNull();
+		});
+
+		it('should reset the birthdate correctly', () => {
+			component.recoveryForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.birthdate').setValue('TEST');
+			creationDataService.emitResetCalled();
+			expect(component.recoveryForm.value[PersonalDataComponent.FORM_GROUP_NAME].birthdate).toEqual({date: null, time: null});
+		});
+
+		it('should reset the certificateLanguage correctly', () => {
+			component.recoveryForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.certificateLanguage').setValue({display: 'TEST', code: 'lang'});
+			creationDataService.emitResetCalled();
+			expect(component.recoveryForm.value[PersonalDataComponent.FORM_GROUP_NAME].certificateLanguage).toEqual({display: 'TEST', code: 'lang'});
+		});
+
+		it('should reset the dateFirstPositiveTestResult correctly', () => {
+			component.recoveryForm.get('dateFirstPositiveTestResult').setValue(datePast);
+			creationDataService.emitResetCalled();
+			expect(component.recoveryForm.value.dateFirstPositiveTestResult).toEqual({date: null, time: null});
+		});
+
+		it('should reset the countryOfTest correctly', () => {
+			component.recoveryForm.get('countryOfTest').setValue('DE');
+			creationDataService.emitResetCalled();
+			expect(component.recoveryForm.value.countryOfTest).toEqual({code: 'CH', display: 'TEST-CH'});
 		});
 	});
 });

--- a/src/app/create/recovery-form/recovery-form.component.spec.ts
+++ b/src/app/create/recovery-form/recovery-form.component.spec.ts
@@ -11,6 +11,7 @@ import {ValueSetsService} from '../utils/value-sets.service';
 import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {CreationDataService} from '../utils/creation-data.service';
 import * as moment from 'moment';
+import {PersonalDataComponent} from "../components/personal-data/personal-data.component";
 
 describe('RecoveryFormComponent', () => {
 	let component: RecoveryFormComponent;
@@ -28,7 +29,7 @@ describe('RecoveryFormComponent', () => {
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
-			declarations: [RecoveryFormComponent, DateTimePickerComponent],
+			declarations: [RecoveryFormComponent, DateTimePickerComponent, PersonalDataComponent],
 			imports: [
 				NoopAnimationsModule,
 				ObliqueTestingModule,
@@ -129,28 +130,49 @@ describe('RecoveryFormComponent', () => {
 		it('should emit next if the form is valid', () => {
 			const nextSpy = jest.spyOn(component.next, 'emit');
 
+			component.recoveryForm.get('personalData.firstName').setValue('John');
+			component.recoveryForm.get('personalData.surName').setValue('Doe');
+			component.recoveryForm.get('personalData.birthdate').setValue({date: datePast});
+			component.recoveryForm.get('personalData.certificateLanguage').setValue('DE');
+
 			component.recoveryForm.get('dateFirstPositiveTestResult').setValue({date: moment(datePast)});
 			component.recoveryForm.get('countryOfTest').setValue('CH');
 
 			component.goNext();
+
+			expect(nextSpy).toHaveBeenCalledTimes(1);
 		});
 
 		it('should call the CreationDataService for setting the new patient data', () => {
 			const setNewPatientSpy = jest.spyOn(creationDataService, 'setNewPatient');
 
+			component.recoveryForm.get('personalData.firstName').setValue('John');
+			component.recoveryForm.get('personalData.surName').setValue('Doe');
+			component.recoveryForm.get('personalData.birthdate').setValue({date: datePast});
+			component.recoveryForm.get('personalData.certificateLanguage').setValue('DE');
+
 			component.recoveryForm.get('dateFirstPositiveTestResult').setValue({date: moment(datePast)});
 			component.recoveryForm.get('countryOfTest').setValue('CH');
 
 			component.goNext();
+
+			expect(setNewPatientSpy).toHaveBeenCalledTimes(1);
 		});
 
 		it('should map the new patient data correctly', () => {
 			const setNewPatientSpy = jest.spyOn(creationDataService, 'setNewPatient');
 
+			component.recoveryForm.get('personalData.firstName').setValue('John');
+			component.recoveryForm.get('personalData.surName').setValue('Doe');
+			component.recoveryForm.get('personalData.birthdate').setValue({date: datePast});
+			component.recoveryForm.get('personalData.certificateLanguage').setValue('DE');
+
 			component.recoveryForm.get('dateFirstPositiveTestResult').setValue({date: moment(datePast)});
 			component.recoveryForm.get('countryOfTest').setValue('CH');
 
 			component.goNext();
+
+			expect(setNewPatientSpy).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/src/app/create/recovery-form/recovery-form.component.ts
+++ b/src/app/create/recovery-form/recovery-form.component.ts
@@ -126,11 +126,13 @@ export class RecoveryFormComponent implements OnInit, AfterViewInit {
 	}
 
 	private resetForm(): void {
-		const previousCertificateLanguage: ProductInfo = this.recoveryForm.value.certificateLanguage;
+		const previousCertificateLanguage: ProductInfo = this.recoveryForm.value[PersonalDataComponent.FORM_GROUP_NAME].certificateLanguage;
 
 		this.formDirective.resetForm();
 		this.recoveryForm.reset({
-			certificateLanguage: previousCertificateLanguage,
+			[PersonalDataComponent.FORM_GROUP_NAME]: {
+				certificateLanguage: previousCertificateLanguage
+			},
 			countryOfTest: this.getDefaultCountryOfRecovery()
 		});
 	}

--- a/src/app/create/recovery-form/recovery-form.component.ts
+++ b/src/app/create/recovery-form/recovery-form.component.ts
@@ -11,7 +11,8 @@ import {PersonalDataComponent} from '../components/personal-data/personal-data.c
 const FIRST_POSITIVE_TEST_VALIDATORS = [
 	Validators.required,
 	DateValidators.dateLessThanToday(),
-	DateValidators.dateMoreThanMinDate()
+	DateValidators.dateMoreThanMinDate(),
+	DateValidators.dateMoreThanBirthday(PersonalDataComponent.FORM_GROUP_NAME)
 ];
 
 @Component({
@@ -27,8 +28,6 @@ export class RecoveryFormComponent implements OnInit, AfterViewInit {
 	@ViewChild('recoveryPersonalDataComponent') personalDataChild: PersonalDataComponent;
 
 	recoveryForm: FormGroup;
-
-	personalDataForm: FormGroup;
 
 	constructor(
 		private readonly formBuilder: FormBuilder,
@@ -53,10 +52,17 @@ export class RecoveryFormComponent implements OnInit, AfterViewInit {
 		});
 	}
 
-	ngAfterViewInit() {
-		if (this.personalDataChild && this.personalDataChild.vaccineForm) {
-			this.personalDataForm = this.personalDataChild.vaccineForm;
-		}
+	ngAfterViewInit(): void {
+		// revalidate the 'dateOfVaccination' field when birthdate is change
+		this.recoveryForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.birthdate').valueChanges.subscribe(() => {
+			// timeout is needed to ensure that the validator gets called after the field contains the new value
+			setTimeout(() => {
+				const control = this.recoveryForm.get('dateFirstPositiveTestResult');
+				// we cannot use AbstractControl::updateValueAndValidity() because then the error message
+				// will contain an object-path for subfield of the ec-datetimepicker
+				control.patchValue(control.value)
+			})
+		});
 	}
 
 	goBack(): void {
@@ -70,11 +76,10 @@ export class RecoveryFormComponent implements OnInit, AfterViewInit {
 		) {
 			this.recoveryForm.markAllAsTouched();
 		}
-		if (this.personalDataForm) {
-			this.personalDataChild.touchDatepicker();
-			this.personalDataForm.markAllAsTouched();
-		}
-		if (this.recoveryForm.valid && this.personalDataForm && this.personalDataForm.valid) {
+
+		this.personalDataChild.touchDatepicker();
+
+		if (this.recoveryForm.valid) {
 			this.dataService.setNewPatient(this.mapFormToPatientData());
 			this.next.emit();
 		}
@@ -97,15 +102,6 @@ export class RecoveryFormComponent implements OnInit, AfterViewInit {
 			dateFirstPositiveTestResult: ['', FIRST_POSITIVE_TEST_VALIDATORS],
 			countryOfTest: [this.getDefaultCountryOfRecovery(), Validators.required]
 		});
-
-		this.recoveryForm.get('dateFirstPositiveTestResult').valueChanges.subscribe(_ => {
-			if (!!this.recoveryForm.get('birthdate')) {
-				this.recoveryForm.controls.dateFirstPositiveTestResult.setValidators([
-					DateValidators.dateMoreThanBirthday(),
-					...FIRST_POSITIVE_TEST_VALIDATORS
-				]);
-			}
-		});
 	}
 
 	private getDefaultCertificateLanguage(): ProductInfo {
@@ -120,10 +116,7 @@ export class RecoveryFormComponent implements OnInit, AfterViewInit {
 
 	private mapFormToPatientData(): Patient {
 		return {
-			firstName: this.personalDataForm.value.firstName,
-			surName: this.personalDataForm.value.surName,
-			birthdate: DateMapper.getBirthdate(this.personalDataForm.value.birthdate),
-			language: this.personalDataForm.value.certificateLanguage.code,
+			...this.personalDataChild.mapFormToPersonalData(),
 			recovery: {
 				countryOfTest: this.recoveryForm.value.countryOfTest,
 				dateFirstPositiveTestResult: DateMapper.getDate(this.recoveryForm.value.dateFirstPositiveTestResult)

--- a/src/app/create/test-form/test-form.component.spec.ts
+++ b/src/app/create/test-form/test-form.component.spec.ts
@@ -13,7 +13,8 @@ import {NO_ERRORS_SCHEMA} from '@angular/core';
 import {CreationDataService} from '../utils/creation-data.service';
 import * as moment from 'moment';
 import {PCR_TEST_CODE, RAPID_TEST_CODE} from 'shared/constants';
-import {GenerationType, ProductInfo} from 'shared/model';
+import {ProductInfo} from 'shared/model';
+import {PersonalDataComponent} from "../components/personal-data/personal-data.component";
 
 describe('TestFormComponent', () => {
 	let component: TestFormComponent;
@@ -40,7 +41,7 @@ describe('TestFormComponent', () => {
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
-			declarations: [TestFormComponent, DateTimePickerComponent],
+			declarations: [TestFormComponent, DateTimePickerComponent, PersonalDataComponent],
 			imports: [
 				NoopAnimationsModule,
 				ObliqueTestingModule,
@@ -237,7 +238,13 @@ describe('TestFormComponent', () => {
 		});
 
 		it('should emit next if the type is selected', () => {
-			const nextMock = jest.spyOn(component.next, 'emit');
+			const nextSpy = jest.spyOn(component.next, 'emit');
+
+			component.testForm.get('personalData.firstName').setValue('John');
+			component.testForm.get('personalData.surName').setValue('Doe');
+			component.testForm.get('personalData.birthdate').setValue({date: datePast});
+			component.testForm.get('personalData.certificateLanguage').setValue('DE');
+
 			component.testForm.get('typeOfTest').setValue({
 				code: 'LP6464-4',
 				display: 'Nucleic acid amplification with probe detection'
@@ -248,11 +255,18 @@ describe('TestFormComponent', () => {
 			component.testForm.get('countryOfTest').setValue('CH');
 
 			component.goNext();
+
+			expect(nextSpy).toHaveBeenCalledTimes(1);
 		});
 
 		it('should call the CreationDataService for setting the new patient data', () => {
 			const setNewPatientSpy = jest.spyOn(creationDataService, 'setNewPatient');
 
+			component.testForm.get('personalData.firstName').setValue('John');
+			component.testForm.get('personalData.surName').setValue('Doe');
+			component.testForm.get('personalData.birthdate').setValue({date: datePast});
+			component.testForm.get('personalData.certificateLanguage').setValue('DE');
+
 			component.testForm.get('typeOfTest').setValue({
 				code: 'LP6464-4',
 				display: 'Nucleic acid amplification with probe detection'
@@ -263,10 +277,17 @@ describe('TestFormComponent', () => {
 			component.testForm.get('countryOfTest').setValue('CH');
 
 			component.goNext();
+
+			expect(setNewPatientSpy).toHaveBeenCalledTimes(1);
 		});
 
 		it('should map the new patient data correctly', () => {
 			const setNewPatientSpy = jest.spyOn(creationDataService, 'setNewPatient');
+
+			component.testForm.get('personalData.firstName').setValue('John');
+			component.testForm.get('personalData.surName').setValue('Doe');
+			component.testForm.get('personalData.birthdate').setValue({date: datePast});
+			component.testForm.get('personalData.certificateLanguage').setValue('DE');
 
 			component.testForm.get('typeOfTest').setValue({
 				code: 'LP6464-4',
@@ -281,6 +302,8 @@ describe('TestFormComponent', () => {
 
 			const sampleDate: Date = moment(datePast).toDate();
 			sampleDate.setHours(12);
+
+			expect(setNewPatientSpy).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/src/app/create/test-form/test-form.component.spec.ts
+++ b/src/app/create/test-form/test-form.component.spec.ts
@@ -182,7 +182,20 @@ describe('TestFormComponent', () => {
 				expect(component.testForm.get('sampleDate').invalid).toBeFalsy();
 			});
 
-			it('should marks the sampleDate as valid if set correctly', () => {
+			it('should mark the sampleDate as valid if set correctly', () => {
+				component.testForm.get('sampleDate').setValue({date: datePast, time: timeNoon});
+				expect(component.testForm.get('sampleDate').invalid).toBeFalsy();
+			});
+
+			it('should mark the sampleDate as invalid if set before birthdate', () => {
+				const dateAhead = moment(datePast).clone().add({days: 1})
+				component.testForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.birthdate').setValue({date: dateAhead.toDate(), time: timeNoon});
+				component.testForm.get('sampleDate').setValue({date: datePast, time: timeNoon});
+				expect(component.testForm.get('sampleDate').invalid).toBeTruthy();
+			});
+
+			it('should mark the sampleDate as valid if set after/equal birthdate', () => {
+				component.testForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.birthdate').setValue(datePast);
 				component.testForm.get('sampleDate').setValue({date: datePast, time: timeNoon});
 				expect(component.testForm.get('sampleDate').invalid).toBeFalsy();
 			});

--- a/src/app/create/test-form/test-form.component.spec.ts
+++ b/src/app/create/test-form/test-form.component.spec.ts
@@ -308,29 +308,29 @@ describe('TestFormComponent', () => {
 	});
 
 	describe('Form reset', () => {
-		/*		it('should reset the firstName correctly', () => {
-			component.testForm.get('firstName').setValue('TEST');
+		it('should reset the firstName correctly', () => {
+			component.testForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.firstName').setValue('TEST');
 			creationDataService.emitResetCalled();
-			expect(component.testForm.value.firstName).toBeNull();
+			expect(component.testForm.value[PersonalDataComponent.FORM_GROUP_NAME].firstName).toBeNull();
 		});
 
 		it('should reset the surName correctly', () => {
-			component.testForm.get('surName').setValue('TEST');
+			component.testForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.surName').setValue('TEST');
 			creationDataService.emitResetCalled();
-			expect(component.testForm.value.surName).toBeNull();
+			expect(component.testForm.value[PersonalDataComponent.FORM_GROUP_NAME].surName).toBeNull();
 		});
 
 		it('should reset the birthdate correctly', () => {
-			component.testForm.get('birthdate').setValue('TEST');
+			component.testForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.birthdate').setValue('TEST');
 			creationDataService.emitResetCalled();
-			expect(component.testForm.value.birthdate).toEqual({date: null, time: null});
+			expect(component.testForm.value[PersonalDataComponent.FORM_GROUP_NAME].birthdate).toEqual({date: null, time: null});
 		});
 
 		it('should reset the certificateLanguage correctly', () => {
-			component.testForm.get('certificateLanguage').setValue({display: 'TEST', code: 'lang'});
+			component.testForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.certificateLanguage').setValue({display: 'TEST', code: 'lang'});
 			creationDataService.emitResetCalled();
-			expect(component.testForm.value.certificateLanguage).toEqual({display: 'TEST', code: 'lang'});
-		});*/
+			expect(component.testForm.value[PersonalDataComponent.FORM_GROUP_NAME].certificateLanguage).toEqual({display: 'TEST', code: 'lang'});
+		});
 
 		it('should reset the typeOfTest correctly', () => {
 			component.testForm.get('typeOfTest').setValue({display: 'TEST', code: 'typeOfTest'});

--- a/src/app/create/test-form/test-form.component.ts
+++ b/src/app/create/test-form/test-form.component.ts
@@ -277,14 +277,16 @@ export class TestFormComponent implements OnInit, AfterViewInit {
 	}
 
 	private resetForm(): void {
-		const previousCertificateLanguage: ProductInfo = this.testForm.value.certificateLanguage;
+		const previousCertificateLanguage: ProductInfo = this.testForm.value[PersonalDataComponent.FORM_GROUP_NAME].certificateLanguage;
 		const previousTypeOfTest: ProductInfo = this.testForm.value.typeOfTest;
 		const previousProduct: ProductInfo = this.testForm.value.product;
 		const previousCenter: string = this.testForm.value.center;
 
 		this.formDirective.resetForm();
 		this.testForm.reset({
-			certificateLanguage: previousCertificateLanguage,
+			[PersonalDataComponent.FORM_GROUP_NAME]: {
+				certificateLanguage: previousCertificateLanguage
+			},
 			countryOfTest: this.getDefaultCountryOfTest(),
 			typeOfTest: previousTypeOfTest,
 			product: previousProduct,

--- a/src/app/create/test-form/test-form.component.ts
+++ b/src/app/create/test-form/test-form.component.ts
@@ -52,8 +52,6 @@ export class TestFormComponent implements OnInit, AfterViewInit {
 	testForm: FormGroup;
 	testType: ProductInfo;
 
-	personalDataForm: FormGroup;
-
 	rapidTestCompleteControl: FormControl;
 	filteredRapidTests: RapidTestProductInfoWithToString[];
 
@@ -98,10 +96,17 @@ export class TestFormComponent implements OnInit, AfterViewInit {
 		this.filteredRapidTests = this.rapidTests;
 	}
 
-	ngAfterViewInit() {
-		if (this.personalDataChild && this.personalDataChild.vaccineForm) {
-			this.personalDataForm = this.personalDataChild.vaccineForm;
-		}
+	ngAfterViewInit(): void {
+		// revalidate the 'sampleDate' field when birthdate is change
+		this.testForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.birthdate').valueChanges.subscribe(() => {
+			// timeout is needed to ensure that the validator gets called after the field contains the new value
+			setTimeout(() => {
+				const control = this.testForm.get('sampleDate');
+				// we cannot use AbstractControl::updateValueAndValidity() because then the error message
+				// will contain an object-path for subfield of the ec-datetimepicker
+				control.patchValue(control.value)
+			})
+		});
 	}
 
 	goBack(): void {
@@ -109,11 +114,9 @@ export class TestFormComponent implements OnInit, AfterViewInit {
 	}
 
 	goNext(): void {
-		if (this.personalDataForm) {
-			this.personalDataChild.touchDatepicker();
-			this.personalDataForm.markAllAsTouched();
-		}
-		if (this.testForm.valid && this.personalDataForm && this.personalDataForm.valid) {
+		this.personalDataChild.touchDatepicker();
+
+		if (this.testForm.valid) {
 			this.dataService.setNewPatient(this.mapFormToPatientData());
 			this.next.emit();
 		}
@@ -191,19 +194,13 @@ export class TestFormComponent implements OnInit, AfterViewInit {
 		}
 		this.testForm = this.formBuilder.group({
 			typeOfTest: [this.testType, Validators.required],
-			sampleDate: [this.rapid ? this.getCurrentDate() : this.getCurrentDateTime(), sampleDateValidators],
+			sampleDate: [this.rapid ? this.getCurrentDate() : this.getCurrentDateTime(), [
+				DateValidators.dateMoreThanBirthday(PersonalDataComponent.FORM_GROUP_NAME),
+				...sampleDateValidators
+			]],
 			countryOfTest: [this.getDefaultCountryOfTest(), Validators.required],
 			product: [''],
 			...(this.rapid ? {center: ['']} : {center: ['', [Validators.required, Validators.maxLength(50)]]})
-		});
-
-		this.testForm.get('sampleDate').valueChanges.subscribe(_ => {
-			if (!!this.testForm.get('birthdate')) {
-				this.testForm.controls.sampleDate.setValidators([
-					DateValidators.dateMoreThanBirthday(),
-					...sampleDateValidators
-				]);
-			}
 		});
 	}
 
@@ -267,10 +264,7 @@ export class TestFormComponent implements OnInit, AfterViewInit {
 		}
 
 		return {
-			firstName: this.personalDataForm.value.firstName,
-			surName: this.personalDataForm.value.surName,
-			birthdate: DateMapper.getBirthdate(this.personalDataForm.value.birthdate),
-			language: this.personalDataForm.value.certificateLanguage.code,
+			...this.personalDataChild.mapFormToPersonalData(),
 			...additionalData
 		};
 	}

--- a/src/app/create/tourist-vaccine-form/tourist-vaccine-form.component.spec.ts
+++ b/src/app/create/tourist-vaccine-form/tourist-vaccine-form.component.spec.ts
@@ -23,6 +23,7 @@ describe.skip('TouristVaccineFormComponent', () => {
 	const dateFuture: Date = new Date('9999-04-29');
 	const datePast: Date = new Date('2000-04-29');
 	const dateToOld: Date = new Date('1899-12-31');
+	const timeNoon = '12:00';
 
 	const mockValueSetsService = {
 		getCertificateLanguages: jest.fn().mockReturnValue([]),
@@ -237,6 +238,19 @@ describe.skip('TouristVaccineFormComponent', () => {
 
 			it('should marks the dateOfVaccination as valid if set correctly', () => {
 				component.vaccineForm.get('dateOfVaccination').setValue({date: datePast});
+				expect(component.vaccineForm.get('dateOfVaccination').invalid).toBeFalsy();
+			});
+
+			it('should mark the dateOfVaccination as invalid if set before birthdate', () => {
+				const dateAhead = moment(datePast).clone().add({days: 1})
+				component.vaccineForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.birthdate').setValue({date: dateAhead.toDate(), time: timeNoon});
+				component.vaccineForm.get('dateOfVaccination').setValue({date: datePast, time: timeNoon});
+				expect(component.vaccineForm.get('dateOfVaccination').invalid).toBeTruthy();
+			});
+
+			it('should mark the dateOfVaccination as valid if set after/equal birthdate', () => {
+				component.vaccineForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.birthdate').setValue(datePast);
+				component.vaccineForm.get('dateOfVaccination').setValue({date: datePast, time: timeNoon});
 				expect(component.vaccineForm.get('dateOfVaccination').invalid).toBeFalsy();
 			});
 		});

--- a/src/app/create/tourist-vaccine-form/tourist-vaccine-form.component.spec.ts
+++ b/src/app/create/tourist-vaccine-form/tourist-vaccine-form.component.spec.ts
@@ -13,6 +13,7 @@ import * as moment from 'moment';
 import {CreationDataService} from '../utils/creation-data.service';
 import {GenerationType} from 'shared/model';
 import {WhoCheckboxComponent} from '../components/who-checkbox/who-checkbox.component';
+import {PersonalDataComponent} from "../components/personal-data/personal-data.component";
 
 describe.skip('TouristVaccineFormComponent', () => {
 	let component: TouristVaccineFormComponent;
@@ -31,7 +32,7 @@ describe.skip('TouristVaccineFormComponent', () => {
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
-			declarations: [TouristVaccineFormComponent, DateTimePickerComponent, WhoCheckboxComponent],
+			declarations: [TouristVaccineFormComponent, DateTimePickerComponent, WhoCheckboxComponent, PersonalDataComponent],
 			imports: [
 				NoopAnimationsModule,
 				ObliqueTestingModule,

--- a/src/app/create/tourist-vaccine-form/tourist-vaccine-form.component.ts
+++ b/src/app/create/tourist-vaccine-form/tourist-vaccine-form.component.ts
@@ -145,11 +145,13 @@ export class TouristVaccineFormComponent implements OnInit, AfterViewInit {
 	}
 
 	private resetForm(): void {
-		const previousCertificateLanguage: ProductInfo = this.vaccineForm.value.certificateLanguage;
+		const previousCertificateLanguage: ProductInfo = this.vaccineForm.value[PersonalDataComponent.FORM_GROUP_NAME].certificateLanguage;
 
 		this.formDirective.resetForm();
 		this.vaccineForm.reset({
-			certificateLanguage: previousCertificateLanguage,
+			[PersonalDataComponent.FORM_GROUP_NAME]: {
+				certificateLanguage: previousCertificateLanguage
+			},
 			dateOfVaccination: TouristVaccineFormComponent.getDefaultDateOfVaccination(),
 			checkBox: false
 		});

--- a/src/app/create/utils/date-validators.ts
+++ b/src/app/create/utils/date-validators.ts
@@ -49,10 +49,19 @@ export class DateValidators {
 		};
 	}
 
-	static dateMoreThanBirthday(formName: string) {
+	static dateMoreThanBirthday(formName?: string) {
 		return (control: AbstractControl): {[key: string]: boolean} | null => {
 			const dateValue: moment.Moment = this.getMomentDate(control.value?.date);
-			const birthdate = this.getMomentDate(control?.parent?.value[formName]?.birthdate?.date);
+			let formValue = control?.parent?.value;
+			if (!formValue) {
+				return null;
+			}
+
+			if (formName) {
+				formValue = formValue[formName];
+			}
+
+			const birthdate = this.getMomentDate(formValue?.birthdate?.date);
 			if (!birthdate || !birthdate.isValid()) {
 				return null;
 			}

--- a/src/app/create/utils/date-validators.ts
+++ b/src/app/create/utils/date-validators.ts
@@ -49,10 +49,13 @@ export class DateValidators {
 		};
 	}
 
-	static dateMoreThanBirthday() {
+	static dateMoreThanBirthday(formName: string) {
 		return (control: AbstractControl): {[key: string]: boolean} | null => {
 			const dateValue: moment.Moment = this.getMomentDate(control.value?.date);
-			const birthdate = this.getMomentDate(control.parent.value.birthdate?.date);
+			const birthdate = this.getMomentDate(control?.parent?.value[formName]?.birthdate?.date);
+			if (!birthdate || !birthdate.isValid()) {
+				return null;
+			}
 			if (!!dateValue && dateValue.isBefore(birthdate)) {
 				return {dateBeforeBirthday: true};
 			}

--- a/src/app/create/vaccine-form/vaccine-form.component.spec.ts
+++ b/src/app/create/vaccine-form/vaccine-form.component.spec.ts
@@ -21,6 +21,7 @@ describe('VaccineFormComponent', () => {
 	const dateFuture: Date = new Date('9999-04-29');
 	const datePast: Date = new Date('2000-04-29');
 	const dateToOld: Date = new Date('1899-12-31');
+	const timeNoon = '12:00';
 
 	const mockValueSetsService = {
 		getCertificateLanguages: jest.fn().mockReturnValue([]),
@@ -200,6 +201,19 @@ describe('VaccineFormComponent', () => {
 
 				expect(component.vaccineForm.invalid).toBeTruthy();
 			});
+		});
+
+		it('should mark the dateOfVaccination as invalid if set before birthdate', () => {
+			const dateAhead = moment(datePast).clone().add({days: 1})
+			component.vaccineForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.birthdate').setValue({date: dateAhead.toDate(), time: timeNoon});
+			component.vaccineForm.get('dateOfVaccination').setValue({date: datePast, time: timeNoon});
+			expect(component.vaccineForm.get('dateOfVaccination').invalid).toBeTruthy();
+		});
+
+		it('should mark the dateOfVaccination as valid if set after/equal birthdate', () => {
+			component.vaccineForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.birthdate').setValue(datePast);
+			component.vaccineForm.get('dateOfVaccination').setValue({date: datePast, time: timeNoon});
+			expect(component.vaccineForm.get('dateOfVaccination').invalid).toBeFalsy();
 		});
 	});
 

--- a/src/app/create/vaccine-form/vaccine-form.component.spec.ts
+++ b/src/app/create/vaccine-form/vaccine-form.component.spec.ts
@@ -279,7 +279,32 @@ describe('VaccineFormComponent', () => {
 			expect(setNewPatientSpy).toHaveBeenCalledTimes(1);
 		});
 	});
+
 	describe('Form reset', () => {
+		it('should reset the firstName correctly', () => {
+			component.vaccineForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.firstName').setValue('TEST');
+			creationDataService.emitResetCalled();
+			expect(component.vaccineForm.value[PersonalDataComponent.FORM_GROUP_NAME].firstName).toBeNull();
+		});
+
+		it('should reset the surName correctly', () => {
+			component.vaccineForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.surName').setValue('TEST');
+			creationDataService.emitResetCalled();
+			expect(component.vaccineForm.value[PersonalDataComponent.FORM_GROUP_NAME].surName).toBeNull();
+		});
+
+		it('should reset the birthdate correctly', () => {
+			component.vaccineForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.birthdate').setValue('TEST');
+			creationDataService.emitResetCalled();
+			expect(component.vaccineForm.value[PersonalDataComponent.FORM_GROUP_NAME].birthdate).toEqual({date: null, time: null});
+		});
+
+		it('should reset the certificateLanguage correctly', () => {
+			component.vaccineForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.certificateLanguage').setValue({display: 'TEST', code: 'lang'});
+			creationDataService.emitResetCalled();
+			expect(component.vaccineForm.value[PersonalDataComponent.FORM_GROUP_NAME].certificateLanguage).toEqual({display: 'TEST', code: 'lang'});
+		});
+
 		it.skip('should reset the medicalProduct correctly', () => {
 			component.vaccineForm.get('medicalProduct').setValue({display: 'TEST', code: 'medicalProduct'});
 			creationDataService.emitResetCalled();

--- a/src/app/create/vaccine-form/vaccine-form.component.spec.ts
+++ b/src/app/create/vaccine-form/vaccine-form.component.spec.ts
@@ -11,6 +11,7 @@ import {DateTimePickerComponent} from '../date-time-picker/date-time-picker.comp
 import {CreationDataService} from '../utils/creation-data.service';
 import {ValueSetsService} from '../utils/value-sets.service';
 import {VaccineFormComponent} from './vaccine-form.component';
+import {PersonalDataComponent} from "../components/personal-data/personal-data.component";
 
 describe('VaccineFormComponent', () => {
 	let component: VaccineFormComponent;
@@ -29,7 +30,7 @@ describe('VaccineFormComponent', () => {
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
-			declarations: [VaccineFormComponent, DateTimePickerComponent],
+			declarations: [VaccineFormComponent, DateTimePickerComponent, PersonalDataComponent],
 			imports: [
 				NoopAnimationsModule,
 				ObliqueTestingModule,
@@ -176,6 +177,11 @@ describe('VaccineFormComponent', () => {
 
 		describe('Cross field validation', () => {
 			it('should marks the form as valid if all fields are filled correctly', () => {
+				component.vaccineForm.get('personalData.firstName').setValue('John');
+				component.vaccineForm.get('personalData.surName').setValue('Doe');
+				component.vaccineForm.get('personalData.birthdate').setValue({date: datePast});
+				component.vaccineForm.get('personalData.certificateLanguage').setValue('DE');
+
 				component.vaccineForm.get('medicalProduct').setValue('testproduct');
 				component.vaccineForm.get('doseNumber').setValue(2);
 				component.vaccineForm.get('totalDoses').setValue(2);
@@ -219,6 +225,11 @@ describe('VaccineFormComponent', () => {
 		it('should emit next if the type is selected', () => {
 			const nextSpy = jest.spyOn(component.next, 'emit');
 
+			component.vaccineForm.get('personalData.firstName').setValue('John');
+			component.vaccineForm.get('personalData.surName').setValue('Doe');
+			component.vaccineForm.get('personalData.birthdate').setValue({date: datePast});
+			component.vaccineForm.get('personalData.certificateLanguage').setValue('DE');
+
 			component.vaccineForm.get('medicalProduct').setValue('testproduct');
 			component.vaccineForm.get('doseNumber').setValue(2);
 			component.vaccineForm.get('totalDoses').setValue(2);
@@ -226,11 +237,18 @@ describe('VaccineFormComponent', () => {
 			component.vaccineForm.get('countryOfVaccination').setValue('CH');
 
 			component.goNext();
+
+			expect(nextSpy).toHaveBeenCalledTimes(1);
 		});
 
 		it('should call the CreationDataService for setting the new patient data', () => {
 			const setNewPatientSpy = jest.spyOn(creationDataService, 'setNewPatient');
 
+			component.vaccineForm.get('personalData.firstName').setValue('John');
+			component.vaccineForm.get('personalData.surName').setValue('Doe');
+			component.vaccineForm.get('personalData.birthdate').setValue({date: datePast});
+			component.vaccineForm.get('personalData.certificateLanguage').setValue('DE');
+
 			component.vaccineForm.get('medicalProduct').setValue({code: '42', display: 'test-product'});
 			component.vaccineForm.get('doseNumber').setValue(2);
 			component.vaccineForm.get('totalDoses').setValue(2);
@@ -238,11 +256,18 @@ describe('VaccineFormComponent', () => {
 			component.vaccineForm.get('countryOfVaccination').setValue({code: 'CH', display: 'test-CH'});
 
 			component.goNext();
+
+			expect(setNewPatientSpy).toHaveBeenCalledTimes(1);
 		});
 
 		it('should map the new patient data correctly', () => {
 			const setNewPatientSpy = jest.spyOn(creationDataService, 'setNewPatient');
 
+			component.vaccineForm.get('personalData.firstName').setValue('John');
+			component.vaccineForm.get('personalData.surName').setValue('Doe');
+			component.vaccineForm.get('personalData.birthdate').setValue({date: datePast});
+			component.vaccineForm.get('personalData.certificateLanguage').setValue('DE');
+
 			component.vaccineForm.get('medicalProduct').setValue({code: '42', display: 'test-product'});
 			component.vaccineForm.get('doseNumber').setValue(2);
 			component.vaccineForm.get('totalDoses').setValue(2);
@@ -250,6 +275,8 @@ describe('VaccineFormComponent', () => {
 			component.vaccineForm.get('countryOfVaccination').setValue({code: 'CH', display: 'test-CH'});
 
 			component.goNext();
+
+			expect(setNewPatientSpy).toHaveBeenCalledTimes(1);
 		});
 	});
 	describe('Form reset', () => {

--- a/src/app/create/vaccine-form/vaccine-form.component.ts
+++ b/src/app/create/vaccine-form/vaccine-form.component.ts
@@ -14,7 +14,8 @@ import {ValueSetsService} from '../utils/value-sets.service';
 const VACCINE_DATE_VALIDATORS = [
 	Validators.required,
 	DateValidators.dateLessThanToday(),
-	DateValidators.dateMoreThanMinDate()
+	DateValidators.dateMoreThanMinDate(),
+	DateValidators.dateMoreThanBirthday(PersonalDataComponent.FORM_GROUP_NAME)
 ];
 
 @Component({
@@ -30,7 +31,6 @@ export class VaccineFormComponent implements OnInit, AfterViewInit {
 	@ViewChild('vaccinePersonalDataComponent') personalDataChild: PersonalDataComponent;
 
 	vaccineForm: FormGroup;
-	personalDataForm: FormGroup;
 
 	public maxDose = 9;
 	public minDose = 0;
@@ -41,6 +41,10 @@ export class VaccineFormComponent implements OnInit, AfterViewInit {
 		private readonly translateService: TranslateService,
 		private readonly dataService: CreationDataService
 	) {}
+
+	private static getDefaultDateOfVaccination(): MomentWrapper {
+		return {date: moment(new Date(), DATE_FORMAT)};
+	}
 
 	ngOnInit(): void {
 		this.createForm();
@@ -59,10 +63,17 @@ export class VaccineFormComponent implements OnInit, AfterViewInit {
 		});
 	}
 
-	ngAfterViewInit() {
-		if (this.personalDataChild && this.personalDataChild.vaccineForm) {
-			this.personalDataForm = this.personalDataChild.vaccineForm;
-		}
+	ngAfterViewInit(): void {
+		// revalidate the 'dateOfVaccination' field when birthdate is change
+		this.vaccineForm.get(PersonalDataComponent.FORM_GROUP_NAME + '.birthdate').valueChanges.subscribe(() => {
+			// timeout is needed to ensure that the validator gets called after the field contains the new value
+			setTimeout(() => {
+				const control = this.vaccineForm.get('dateOfVaccination');
+				// we cannot use AbstractControl::updateValueAndValidity() because then the error message
+				// will contain an object-path for subfield of the ec-datetimepicker
+				control.patchValue(control.value)
+			})
+		});
 	}
 
 	goBack(): void {
@@ -71,11 +82,9 @@ export class VaccineFormComponent implements OnInit, AfterViewInit {
 
 	goNext(): void {
 		this.vaccineForm.markAllAsTouched();
-		if (this.personalDataForm) {
-			this.personalDataChild.touchDatepicker();
-			this.personalDataForm.markAllAsTouched();
-		}
-		if (this.vaccineForm.valid && this.personalDataForm && this.personalDataForm.valid) {
+		this.personalDataChild.touchDatepicker();
+
+		if (this.vaccineForm.valid) {
 			this.dataService.setNewPatient(this.mapFormToPatientData());
 			this.next.emit();
 		}
@@ -106,20 +115,11 @@ export class VaccineFormComponent implements OnInit, AfterViewInit {
 				medicalProduct: ['', Validators.required],
 				doseNumber: ['', [Validators.required, Validators.max(9), Validators.min(1)]],
 				totalDoses: ['', [Validators.required, Validators.max(9), Validators.min(1)]],
-				dateOfVaccination: [this.getDefaultDateOfVaccination(), VACCINE_DATE_VALIDATORS],
+				dateOfVaccination: [VaccineFormComponent.getDefaultDateOfVaccination(), VACCINE_DATE_VALIDATORS],
 				countryOfVaccination: [this.getDefaultCountryOfVaccination(), Validators.required]
 			},
 			{validators: [DosesValidators.validateDoses, IssuableProductValidator.validateProduct]}
 		);
-
-		this.vaccineForm.get('dateOfVaccination').valueChanges.subscribe(_ => {
-			if (!!this.vaccineForm.get('birthdate')) {
-				this.vaccineForm.controls.dateOfVaccination.setValidators([
-					DateValidators.dateMoreThanBirthday(),
-					...VACCINE_DATE_VALIDATORS
-				]);
-			}
-		});
 	}
 
 	private getDefaultCertificateLanguage(): ProductInfo {
@@ -132,16 +132,9 @@ export class VaccineFormComponent implements OnInit, AfterViewInit {
 		return this.getCountriesOfVaccination().find(countryCode => countryCode.code === 'CH');
 	}
 
-	private getDefaultDateOfVaccination(): MomentWrapper {
-		return {date: moment(new Date(), DATE_FORMAT)};
-	}
-
 	private mapFormToPatientData(): Patient {
 		return {
-			firstName: this.personalDataForm.value.firstName,
-			surName: this.personalDataForm.value.surName,
-			birthdate: DateMapper.getBirthdate(this.personalDataForm.value.birthdate),
-			language: this.personalDataForm.value.certificateLanguage.code,
+			...this.personalDataChild.mapFormToPersonalData(),
 			vaccination: {
 				countryOfVaccination: this.vaccineForm.value.countryOfVaccination,
 				dateOfVaccination: DateMapper.getDate(this.vaccineForm.value.dateOfVaccination),
@@ -159,7 +152,7 @@ export class VaccineFormComponent implements OnInit, AfterViewInit {
 		this.formDirective.resetForm();
 		this.vaccineForm.reset({
 			certificateLanguage: previousCertificateLanguage,
-			dateOfVaccination: this.getDefaultDateOfVaccination(),
+			dateOfVaccination: VaccineFormComponent.getDefaultDateOfVaccination(),
 			countryOfVaccination: this.getDefaultCountryOfVaccination()
 		});
 	}

--- a/src/app/create/vaccine-form/vaccine-form.component.ts
+++ b/src/app/create/vaccine-form/vaccine-form.component.ts
@@ -147,11 +147,13 @@ export class VaccineFormComponent implements OnInit, AfterViewInit {
 	}
 
 	private resetForm(): void {
-		const previousCertificateLanguage: ProductInfo = this.vaccineForm.value.certificateLanguage;
+		const previousCertificateLanguage: ProductInfo = this.vaccineForm.value[PersonalDataComponent.FORM_GROUP_NAME].certificateLanguage;
 
 		this.formDirective.resetForm();
 		this.vaccineForm.reset({
-			certificateLanguage: previousCertificateLanguage,
+			[PersonalDataComponent.FORM_GROUP_NAME]: {
+				certificateLanguage: previousCertificateLanguage
+			},
 			dateOfVaccination: VaccineFormComponent.getDefaultDateOfVaccination(),
 			countryOfVaccination: this.getDefaultCountryOfVaccination()
 		});

--- a/src/app/shared/model.ts
+++ b/src/app/shared/model.ts
@@ -3,16 +3,19 @@ import {Moment} from 'moment';
 
 export const DATE_FORMAT = 'dd.MM.YYYY';
 
-export interface Patient {
+export interface PersonalData {
 	firstName: string; // maxChar 50
 	surName: string; // maxChar 50
 	birthdate: Date | string; // between 1900-01-01 and 2099-12-31 (this format)
+	language: string;
+}
+
+export interface Patient extends PersonalData {
 	vaccination?: Vaccination;
 	test?: Test;
 	recovery?: Recovery;
 	antibody?: Antibody;
 	exceptional?: Exceptional;
-	language: string;
 	certificateType: GenerationType;
 }
 


### PR DESCRIPTION
**Please dont merge this request yet!** This PR can only be merged once the backend and API gateway test has been corrected. This will be discussed in the next daily meeting.

This PR essentielly corrects an date validator which ensures that the birthdate is equal or before the certificate date (sampleDate, dateFirstPositiveTestResult, etc.). The validator already existed but stopped working. This has been discovered by our tester in the april 2022. It stopped working because of an angular update around november 2021. The validator used to be manually triggered when the sampleDate field was changed. Unfortunately the new version of angular executed the validator before the field has set the new value ( = instable state). Meaning the validator received a NULL object.

The following steps were necessary to fix this issue:
- Change nested oblique forms into nested angular forms
  - Correcting the unit tests
  - Correcting the validator
  - Correcting the controllers (object mapping for the requests and resetting the form)
- Adding the necessary unit test for regression tests
- Adding a missing unittest for the ExceptionalFormComponent